### PR TITLE
Remove redundant static asset import (improve web performance)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "bootstrap": "4.0.0",
     "chart.js": "2.7.1",
     "event-source-polyfill": "0.0.12",
-    "flag-icon-css": "2.9.0",
     "font-awesome": "4.7.0",
     "formik": "^0.11.11",
     "history": "4.7.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,9 +2,6 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
-// Styles
-// Import Flag Icons Set
-import 'flag-icon-css/css/flag-icon.min.css';
 // Import Font Awesome Icons Set
 import 'font-awesome/css/font-awesome.min.css';
 // Import Simple Line Icons Set


### PR DESCRIPTION
I saw a lot of request redundant. It up to 500 requests or more, it request flags of all country around the world. LOL
![image](https://user-images.githubusercontent.com/28921466/40042480-c22409fa-584b-11e8-98c5-bd5f76090f5f.png)
