### PR TITLE
Cancel subscribe to prevent Error message everywhere

### DIFF
--- a/src/Modules/User/Components/Profile/Favorite/Favorite.tsx
+++ b/src/Modules/User/Components/Profile/Favorite/Favorite.tsx
@@ -5,6 +5,7 @@ import { FavoriteSongItem } from 'Models/FavoriteSong/FavoriteSongItem';
 import { updateNewestFavoriteList } from 'Modules/User/Redux/Actions';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { Subscription } from 'rxjs/Subscription';
 import { UserServices } from 'Services/Http';
 import './Favorite.scss';
 import { FavoriteItem } from './FavoriteItem';
@@ -26,6 +27,8 @@ class FavoriteComponent extends BaseComponent<
   IOwnStates
 > {
   @Inject('UserServices') private userServices: UserServices;
+  private getListMyFavoriteSub: Subscription;
+
   constructor(props: IReduxProps & IDispatcherProps) {
     super(props);
 
@@ -39,7 +42,7 @@ class FavoriteComponent extends BaseComponent<
   }
 
   public getListFavoriteSong() {
-    this.userServices.getListMyFavorite().subscribe(
+    this.getListMyFavoriteSub = this.userServices.getListMyFavorite().subscribe(
       (favoriteSongItem: FavoriteSongItem[]) => {
         this.props.updateNewestFavoriteList(favoriteSongItem);
         this.setState({
@@ -59,6 +62,10 @@ class FavoriteComponent extends BaseComponent<
         favoriteList,
       });
     }
+  }
+
+  public componentWillUnmount() {
+    this.cancelSubscription();
   }
 
   public renderFavoriteListEmpty() {
@@ -94,6 +101,12 @@ class FavoriteComponent extends BaseComponent<
           : this.renderFavoriteList()}
       </div>
     );
+  }
+
+  private cancelSubscription() {
+    if (this.getListMyFavoriteSub) {
+      this.getListMyFavoriteSub.unsubscribe();
+    }
   }
 }
 

--- a/src/Modules/User/Components/Profile/MyStationsBrowser/MyStationsBrowser.tsx
+++ b/src/Modules/User/Components/Profile/MyStationsBrowser/MyStationsBrowser.tsx
@@ -2,13 +2,19 @@ import { Inject } from 'Configuration/DependencyInjection';
 import { StationInfo } from 'Models';
 import { BaseStationBrowser } from 'Modules/Station';
 import * as React from 'react';
+import { Subscription } from 'rxjs/Subscription';
 import { UserServices } from 'Services/Http';
 
 export class MyStationsBrowser extends BaseStationBrowser<{}> {
   @Inject('UserServices') private userServices: UserServices;
+  private getListMyStationSub: Subscription;
 
   public componentWillMount() {
     this.getListStation();
+  }
+
+  public componentWillUnmount() {
+    this.cancelSubscription();
   }
 
   public getListStation() {
@@ -31,5 +37,11 @@ export class MyStationsBrowser extends BaseStationBrowser<{}> {
 
   public getNoStationFoundMessage() {
     return 'You have no station';
+  }
+
+  private cancelSubscription() {
+    if (this.getListMyStationSub) {
+      this.getListMyStationSub.unsubscribe();
+    }
   }
 }

--- a/src/Modules/User/Components/Profile/MyStationsBrowser/UserStationsBrowser.tsx
+++ b/src/Modules/User/Components/Profile/MyStationsBrowser/UserStationsBrowser.tsx
@@ -3,6 +3,7 @@ import { StationInfo } from 'Models';
 import { RegisteredUser } from 'Models/User';
 import { BaseStationBrowser } from 'Modules/Station';
 import * as React from 'react';
+import { Subscription } from 'rxjs/Subscription';
 import { UserServices } from 'Services/Http';
 
 interface IProps {
@@ -11,9 +12,14 @@ interface IProps {
 
 export class UserStationsBrowser extends BaseStationBrowser<IProps> {
   @Inject('UserServices') private userServices: UserServices;
+  private getUserStationSub: Subscription;
 
   public componentWillMount() {
     this.getListStation();
+  }
+
+  public componentWillUnmount() {
+    this.cancelSubscription();
   }
 
   public getListStation() {
@@ -38,6 +44,12 @@ export class UserStationsBrowser extends BaseStationBrowser<IProps> {
     const { userInfo } = this.props;
     if (userInfo) {
       return userInfo.name + ' has no station';
+    }
+  }
+
+  private cancelSubscription() {
+    if (this.getUserStationSub) {
+      this.getUserStationSub.unsubscribe();
     }
   }
 }

--- a/src/Modules/User/Components/Profile/RecentStationsBrowser/MyRecentStationsBrowser.tsx
+++ b/src/Modules/User/Components/Profile/RecentStationsBrowser/MyRecentStationsBrowser.tsx
@@ -1,13 +1,19 @@
 import { Inject } from 'Configuration/DependencyInjection';
 import { StationInfo } from 'Models';
 import { BaseStationBrowser } from 'Modules/Station';
+import { Subscription } from 'rxjs/Subscription';
 import { UserServices } from 'Services/Http';
 
 export class MyRecentStationsBrowser extends BaseStationBrowser<{}> {
   @Inject('UserServices') private userServices: UserServices;
+  private getListMyRecentStationSub: Subscription;
 
   public componentWillMount() {
     this.getListStation();
+  }
+
+  public componentWillUnmount() {
+    this.cancelSubscription();
   }
 
   public getListStation() {
@@ -30,5 +36,11 @@ export class MyRecentStationsBrowser extends BaseStationBrowser<{}> {
 
   public getNoStationFoundMessage() {
     return "You haven't interact with any station yet";
+  }
+
+  private cancelSubscription() {
+    if (this.getListMyRecentStationSub) {
+      this.getListMyRecentStationSub.unsubscribe();
+    }
   }
 }

--- a/src/Modules/User/Components/Profile/RecentStationsBrowser/UserRecentStationsBrowser.tsx
+++ b/src/Modules/User/Components/Profile/RecentStationsBrowser/UserRecentStationsBrowser.tsx
@@ -2,6 +2,7 @@ import { Inject } from 'Configuration/DependencyInjection';
 import { RegisteredUser } from 'Models/User';
 import { BaseStationBrowser } from 'Modules/Station';
 import * as React from 'react';
+import { Subscription } from 'rxjs/Subscription';
 import { UserServices } from 'Services/Http';
 
 interface IProps {
@@ -10,9 +11,14 @@ interface IProps {
 
 export class UserRecentStationsBrowser extends BaseStationBrowser<IProps> {
   @Inject('UserServices') private userServices: UserServices;
+  private getUserRecentStationSub: Subscription;
 
   public componentWillMount() {
     this.getListStation();
+  }
+
+  public componentWillUnmount() {
+    this.cancelSubscription();
   }
 
   public getListStation() {
@@ -37,6 +43,12 @@ export class UserRecentStationsBrowser extends BaseStationBrowser<IProps> {
     const { userInfo } = this.props;
     if (userInfo) {
       return userInfo.name + " hasn't interact with any station yet";
+    }
+  }
+
+  private cancelSubscription() {
+    if (this.getUserRecentStationSub) {
+      this.getUserRecentStationSub.unsubscribe();
     }
   }
 }


### PR DESCRIPTION
When user visits a page, it will make some requests to server and go to other page immediately.
Sometimes, the requests on the previous page take a while to get results, maybe a error message, and then it will appear in the next page.

<i>Example:</i> Get history error message